### PR TITLE
Siemens JSON support

### DIFF
--- a/siemens/fwf_gwf_list_from_siemens_json.m
+++ b/siemens/fwf_gwf_list_from_siemens_json.m
@@ -1,0 +1,26 @@
+function [gwfc, rfc, dtc, ind2] = fwf_gwf_list_from_siemens_json(json, gamma, u, n, ind2)
+% function [gwfc, rfc, dtc, ind2] = fwf_gwf_list_from_siemens_json(json)
+% By Markus Nilsson
+% Lund University, Lund, Sweden
+%
+% Returns cell array of actually executed waveforms.
+% Completely unvalidated.
+
+
+seq              = fwf_seq_from_siemens_json(json);
+[gwfo, rfo, dto] = fwf_gwf_from_siemens_seq(seq);
+R3x3             = fwf_rm_from_siemens_uvec(u, seq.rot_mode, n*2*pi);
+
+% Create normalized waveforms
+for i = 1:numel(gwfo)
+    bnrm   = trace(fwf_gwf_to_btens(gwfo{i}, rfo{i}, dto{i}, gamma));
+    wfn{i} = gwfo{i} * sqrt(seq.b_max_requ*1e6/bnrm);
+end
+
+% Compile gwf cells with rotations and scaling
+for i = 1:numel(n)
+    R       = R3x3(:,:,i);
+    gwfc{i} = (R * wfn{ind2(i)}')' * n(i);
+    rfc{i}  = rfo{ind2(i)};
+    dtc{i}  = dto{ind2(i)};
+end

--- a/siemens/fwf_seq_from_siemens_json.m
+++ b/siemens/fwf_seq_from_siemens_json.m
@@ -1,0 +1,114 @@
+function res = fwf_seq_from_siemens_json(json)
+% function res = fwf_seq_from_siemens_json(json)
+% By Markus Nilsson
+% Lund University, Lund, Sweden
+%
+% json created by a modified dcm2niix binary
+%
+% NOTE: This function must be expanded with version control as the position
+% and meaning of each field may change!
+
+
+str_list = {...
+    
+% UI parameters
+'alFree[21]',              'study_nr',     'enum';
+'alFree[22]',              'wf_nr',        'enum';
+'alFree[23]',              'rot_mode',     'enum';
+'alFree[24]',              'norm_mode',    'enum';
+'alFree[25]',              'post_wf_mode', 'enum';
+'alFree[26]',              'timing_mode',  'enum';
+'alFree[27]',              'pause_mode',   'enum';
+'alFree[28]',              'bg_on',        'enum';
+'alFree[29]',              'header_mode',  'enum';
+'alFree[31]',              'b_max',        'mm2/ms';
+'alFree[32]',              'd_pre',        'µs';
+'alFree[33]',              'd_post',       'µs';
+'alFree[34]',              'd_pause',      'µs';
+
+% sequence timing
+'alFree[41]',              'd_pre_max',    'µs';
+'alFree[42]',              'd_post_max',   'µs';
+'alFree[43]',              'd_pause_min',  'µs';
+'alFree[44]',              'd_pause_max',  'µs';
+
+'alFree[60]',               't_start',      'µs'; % v1.19
+
+% validation params
+'alFree[45]',              'study_nr_curr','enum';
+'alFree[46]',              'wf_nr_curr',   'enum';
+'alFree[47]',              'b_max_gamp',   'mm2/ms';
+'alFree[48]',              'b_max_slew',   'mm2/ms';
+'alFree[49]',              'b_max_requ',   'mm2/ms';
+
+% waveform info
+'alFree[50]',              'gamp',         'mT/m*1000';
+'alFree[51]',              'slew',         'T/m/s*1000';
+'alFree[52]',              'B_FA',         '1*1000';
+'alFree[53]',              'didi_norm',    '1*1000';
+
+% b-tensor
+'alFree[54]',              'Bxx',          'ms/µm2*1000';
+'alFree[55]',              'Byy',          'ms/µm2*1000';
+'alFree[56]',              'Bzz',          'ms/µm2*1000';
+'alFree[57]',              'Bxy',          'ms/µm2*1000';
+'alFree[58]',              'Bxz',          'ms/µm2*1000';
+'alFree[59]',              'Byz',          'ms/µm2*1000';
+
+% balance gradient
+'adFree[8]',              'bg_ampx',      'mT/m';
+'adFree[9]',              'bg_ampy',      'mT/m';
+'adFree[10]',             'bg_ampz',      'mT/m';
+'adFree[11]',             'bg_0mom',      'mTs/m';
+
+% loaded waveform in base 64
+'WipMemBlock',             'wf_stored',    'str';
+
+% Siemens imaging parameters
+'PulseSequenceDetails',             'seq_dll_fn',   'str';
+'ImagingFrequency',                 'f0',           'MHz';
+'BaseResolution',                   'MatrixSize',   'int';
+'PhaseEncodingSteps',               'MatrixSizePh', 'int';
+'ParallelReductionFactorInPlane',   'iPAT',         'int';
+'SliceThickness',                   'SliceThick',   'mm';
+'SequenceName',                     'SeqName',      'str';
+'ProtocolName',                     'ProtName',     'str';
+'MultibandAccelerationFactor',      'MBFactor',     'int';
+
+};
+
+% json
+
+for i = 1:size(str_list, 1)
+
+    % Search for field name
+    fn = str_list{i,1};
+    fn = strrep(fn, '[', '_');
+    fn = strrep(fn, ']', '_');
+
+    if (contains(fn, 'alFree')) || (contains(fn, 'adFree'))
+        fn = sprintf('FWF_%s', fn);
+    end
+
+    if (isfield(json, fn))
+
+        val = json.(fn);
+
+        if (strcmp(fn, 'WipMemBlock'))
+            val = fwf_b64_to_data(val);
+            res.fwf_seq_version = str2double(val.version);
+            res.unit.fwf_seq_version_unit = 'ordinal';        
+        end
+
+        res.(str_list{i,2}) = val;
+
+
+    else
+        fprintf('Did not find: %s\n', str_list{i});
+    end    
+    
+    
+end
+
+
+

--- a/siemens/fwf_xps_from_siemens_json.m
+++ b/siemens/fwf_xps_from_siemens_json.m
@@ -1,0 +1,58 @@
+function xps = fwf_xps_from_siemens_json(nii_fn)
+% function xps = fwf_xps_from_siemens_json(nii_fn)
+
+    function txt = fread_all(txt_fn)
+        fid = fopen(txt_fn);
+        txt = char(fread(fid, inf, 'char')');
+        fclose(fid);
+    end
+
+if (nargin == 0)
+    error('need to supply file name');
+end
+
+% Construct file names
+[bp, name, ext] = fileparts(nii_fn);
+[~,name] = fileparts(name); % for nii.gz
+
+json_fn = fullfile(bp, [name '.json']);
+bval_fn = fullfile(bp, [name '.bval']);
+bvec_fn = fullfile(bp, [name '.bvec']);
+
+assert(exist(json_fn, 'file'), 'Did not find json file: %s', json_fn);
+assert(exist(bvec_fn, 'file'), 'Did not find bvec file: %s', bvec_fn);
+assert(exist(bval_fn, 'file'), 'Did not find bval file: %s', bval_fn);
+
+
+% Json and create raw waveforms from it
+json = jsondecode(fread_all(json_fn));
+
+gamma = json.ImagingFrequency * 1e6 * 2 * pi;
+
+% Load bval and bvec files
+b = fread_all(bval_fn);
+b = str2num(b)' * 1e6;
+
+n = sqrt(b / max(b));
+
+u = fread_all(bvec_fn);
+u = str2num(u)';
+
+ind2 = ones(size(b));
+
+[gwfc, rfc, dtc, ind] = fwf_gwf_list_from_siemens_json(json,gamma,u,n,ind2);
+
+
+btl = zeros(numel(gwfc), 6);
+for i = 1:numel(gwfc)
+    bt3x3    = fwf_gwf_to_btens(gwfc{i}, rfc{i}, dtc{i}, gamma);
+    btl(i,:) = tm_3x3_to_1x6(bt3x3);
+end
+
+xps           = mdm_xps_from_bt(btl);
+xps.te        = ones(xps.n, 1) * json.EchoTime;
+xps.tr        = ones(xps.n, 1) * json.RepetitionTime;
+xps.wf_ind    = ind;
+
+end
+

--- a/siemens/readme.md
+++ b/siemens/readme.md
@@ -42,4 +42,4 @@ nii_fn = 'my_data.nii.gz'; % processed using the dcm2niix fork linked above
 xps = fwf_xps_from_siemens_json(nii_fn);
 ```
 
-This function assumes the .json, .bval, and .bvec files are has names similar to the nifti file. 
+This function assumes the .json, .bval, and .bvec files has names derived from the nifti file. 

--- a/siemens/readme.md
+++ b/siemens/readme.md
@@ -31,3 +31,15 @@ load('path_to_dicm2nii_output_folder\dcmHeaders.mat')
 xps_l = fwf_xps_from_dicm2nii_h_struct(h, 'path_to_my_output_folder')
 
 ```
+
+
+## Alternative approach
+
+The [dcm2niix](https://github.com/rordenlab/dcm2niix) tool creates a JSON file with metadata from the Siemens CSA header. However, in the master version as of 2023-08-25, the length of the WipMemBlock is limited to 256 characters, and in addition, it does not export 'tFree' fields at all. A modified version is available [here](https://github.com/markus-nilsson/dcm2niix). Note that you need to compile this version yourself. This fork creates a .json file that can be used according to the example below. 
+
+```
+nii_fn = 'my_data.nii.gz'; % processed using the dcm2niix fork linked above
+xps = fwf_xps_from_siemens_json(nii_fn);
+```
+
+This function assumes the .json, .bval, and .bvec files are has names similar to the nifti file. 


### PR DESCRIPTION
See description in readme.md file in the Siemens folder. You may want to put the str_list info a separate function, so that it does not have to be maintained in two places. Similarly, the 'fwf_gwf_list_from_siemens_json' function should share functionality with the corresponding hdr one, but I did not find a better way than this. Finally, note that dcm2niix can be made to pull out diffusion directions from the CSA header, but that's a more cumbersome task.